### PR TITLE
voicemeeter support (and fix)

### DIFF
--- a/AndroidUsbAudioSource/src/android_usb_audio_source.cpp
+++ b/AndroidUsbAudioSource/src/android_usb_audio_source.cpp
@@ -50,11 +50,16 @@ PaStream* InitPortAudio() {
         auto global_idx = Pa_HostApiDeviceIndexToDeviceIndex(api_idx, i);
         const auto* device = Pa_GetDeviceInfo(global_idx);
         
-        if (std::string{device->name}.find("VB-Audio") != std::string::npos &&
+        // First - try to get Virtual Cable, if couldn't - try to get VoiceMeeter(or something else with VB-Audio in the name)
+        if (std::string{device->name}.find("VB-Audio Virtual Cable") != std::string::npos &&
             device->maxInputChannels > 0) {
             device_info = device;
             device_idx = global_idx;
             break;
+        } else if (std::string{ device->name }.find("VB-Audio") != std::string::npos &&
+            device->maxInputChannels > 0) {
+            device_info = device;
+            device_idx = global_idx;
         }
     }
     if (!device_info) {


### PR DESCRIPTION
added VoiceMeeter as a backup solution to VB-Audio Cable:
if VB-Audio Cable is not found AudioSource will try to use VoiceMeeter's devices instead
(btw, it tried to use VoiceMeeter insted of VB-Audio Cable by default)